### PR TITLE
Add modular Python slither bot implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,69 @@
+# SlitherBOT
+
+A modular Python automation bot for [slither.io](https://slither.io/) style servers. The bot connects to a WebSocket endpoint, keeps track of the world state and selects actions using configurable strategies such as farming, hunting and survival.
+
+> **Note**: The provided protocol assumes a JSON-based self-hosted server used for testing purposes. When targeting the original slither.io protocol, a translation layer is required because the official servers use a custom binary format.
+
+## Features
+
+- 🧠 **Strategy modes**: farm (passive growth), hunt (aggressive targeting) and survival (defensive play). Modes can be switched on-the-fly through server messages.
+- 🛰️ **State tracking**: continuously updates knowledge about snakes, food pellets and temporary hazards.
+- 🚀 **Responsive movement**: smooth heading interpolation and configurable boost usage for fast reflexes.
+- 🔌 **Plugin hooks**: register custom plugins to react to bot events or implement additional behaviours.
+- 🔁 **Robust connection handling**: automatic heartbeat, reconnection backoff and rate-limited command dispatch.
+
+## Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+## Running the bot
+
+```bash
+slitherbot ws://127.0.0.1:4444 "SneakyBot" --mode hunt --config heartbeat_interval=2.0 send_rate_limit=0.05
+```
+
+The `--config` option accepts additional `key=value` overrides for any `BotConfig` field.
+
+## Integrating with a server
+
+The reference implementation expects the following JSON messages over WebSocket:
+
+### Server → Bot
+
+- `{"type": "world", "payload": {"size": [width, height]}}`
+- `{"type": "snake", "payload": {"id": "unique", "x": 100, "y": 200, "heading": 90, "length": 120, "speed": 4.5, "self": false, "name": "enemy"}}`
+- `{"type": "snake_leave", "payload": {"id": "unique"}}`
+- `{"type": "food_batch", "payload": {"items": [[x, y, mass], ...]}}`
+- `{"type": "hazard", "payload": {"x": 100, "y": 40, "radius": 30, "duration": 1.5}}`
+- `{"type": "mode", "payload": {"value": "hunt"}}`
+
+### Bot → Server
+
+- `{"type": "join", "payload": {"nickname": "SneakyBot"}}`
+- `{"type": "heartbeat", "payload": {"time": 1690000000.0}}`
+- `{"type": "move", "payload": {"heading": 90.0, "boost": true, "throttle": 4.5, "reason": "hunt"}}`
+
+These messages are easy to adapt to a custom self-hosted environment. When interfacing with the official servers, replace `slitherbot.protocol.SlitherProtocol` with one that speaks the binary protocol and converts messages into the structures understood by the bot.
+
+## Extending the bot
+
+Create a plugin by inheriting from `slitherbot.bot.BasePlugin` and registering it with `SlitherBot.register_plugin`. Plugins receive asynchronous events via `handle` and can be used for telemetry, adaptive tuning or external controls.
+
+Strategy logic can be customised by implementing a new class derived from `slitherbot.strategies.BaseStrategy` and swapping it at runtime using `SlitherBot.set_mode` or by calling `ActionPlanner.update_strategy` directly.
+
+## Development
+
+```bash
+pip install -e .[dev]
+pytest
+```
+
+Tests are not included by default but the project structure is ready for unit testing (e.g. mocking the protocol and validating planner behaviour).
+
+## License
+
+MIT

--- a/Readme.MD
+++ b/Readme.MD
@@ -1,1 +1,0 @@
-The best bot

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "slitherbot"
+version = "0.1.0"
+description = "Modular slither.io automation bot"
+readme = "README.md"
+authors = [{name = "Slither Bot"}]
+requires-python = ">=3.9"
+dependencies = [
+    "websockets>=11.0",
+    "pydantic>=1.10",
+    "numpy>=1.24"
+]
+
+[project.scripts]
+slitherbot = "slitherbot.cli:main"
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/slitherbot/__init__.py
+++ b/slitherbot/__init__.py
@@ -1,0 +1,6 @@
+"""Top level package for the Slither automation bot."""
+
+from .bot import SlitherBot
+from .config import BotConfig, StrategyMode
+
+__all__ = ["SlitherBot", "BotConfig", "StrategyMode"]

--- a/slitherbot/bot.py
+++ b/slitherbot/bot.py
@@ -1,0 +1,135 @@
+"""High level orchestration for the Slither bot."""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Dict, Optional
+
+from .config import BotConfig, StrategyMode
+from .planner import ActionPlanner
+from .protocol import IncomingMessage, SlitherProtocol
+from .state import Food, GameState, Snake, Vector2
+from .strategies import BaseStrategy, make_strategy
+
+LOGGER = logging.getLogger(__name__)
+
+
+class SlitherBot:
+    """Entry point for connecting to a slither server and automating gameplay."""
+
+    def __init__(self, config: Optional[BotConfig] = None) -> None:
+        self.config = config or BotConfig()
+        self.state = GameState()
+        self._strategy: BaseStrategy = make_strategy(self.config.mode, self.config)
+        self._planner = ActionPlanner(self.config, self._strategy)
+        self._protocol: Optional[SlitherProtocol] = None
+        self._last_send = 0.0
+        self._plugins: Dict[str, BasePlugin] = {}
+
+    async def run(self) -> None:
+        """Connect to the server and enter the main update loop."""
+
+        retries = 0
+        while retries <= self.config.reconnect_attempts:
+            try:
+                async with SlitherProtocol(self.config.server_url, self.config.heartbeat_interval) as protocol:
+                    self._protocol = protocol
+                    await protocol.send(
+                        {
+                            "type": "join",
+                            "payload": {"nickname": self.config.sanitized_nickname()},
+                        }
+                    )
+                    await self._loop(protocol)
+            except Exception as exc:
+                LOGGER.exception("Bot loop error: %s", exc)
+            retries += 1
+            await asyncio.sleep(self.config.reconnect_backoff * retries)
+            LOGGER.info("Reconnect attempt %s", retries)
+
+    async def _loop(self, protocol: SlitherProtocol) -> None:
+        async for message in protocol.messages():
+            now = time.monotonic()
+            await self._handle_message(message, now)
+            await self._maybe_act(now)
+
+    async def _handle_message(self, message: IncomingMessage, now: float) -> None:
+        if message.type == "world" and "size" in message.payload:
+            self.state.world_size = tuple(message.payload["size"])  # type: ignore[assignment]
+        elif message.type == "snake" and "id" in message.payload:
+            snake = Snake(
+                id=str(message.payload["id"]),
+                position=Vector2(message.payload.get("x", 0.0), message.payload.get("y", 0.0)),
+                heading=message.payload.get("heading", 0.0),
+                length=message.payload.get("length", 0.0),
+                speed=message.payload.get("speed", self.config.movement_tuning.base_speed),
+                is_self=message.payload.get("self", False),
+                name=message.payload.get("name"),
+            )
+            self.state.update_snakes([snake])
+        elif message.type == "snake_leave":
+            self.state.remove_snake(str(message.payload.get("id")))
+        elif message.type == "food_batch":
+            foods = [
+                Food(
+                    position=Vector2(item[0], item[1]),
+                    mass=item[2],
+                    created=now,
+                )
+                for item in message.payload.get("items", [])
+            ]
+            self.state.update_food(foods)
+        elif message.type == "hazard":
+            self.state.mark_hazard(
+                center=Vector2(message.payload.get("x", 0.0), message.payload.get("y", 0.0)),
+                radius=message.payload.get("radius", 20.0),
+                expires=now + message.payload.get("duration", 2.0),
+            )
+        elif message.type == "mode":
+            mode = StrategyMode(message.payload.get("value", self.config.mode.value))
+            self.set_mode(mode)
+        self.state.decay_food(now, self.config.sensor_tuning.food_decay_seconds)
+        self.state.prune_hazards(now)
+
+    async def _maybe_act(self, now: float) -> None:
+        if not self._protocol:
+            return
+        if now - self._last_send < self.config.send_rate_limit:
+            return
+        plan = self._planner.step(self.state, now)
+        message = {
+            "type": "move",
+            "payload": {
+                "heading": plan.heading,
+                "boost": plan.boost,
+                "throttle": plan.throttle,
+                "reason": plan.reason,
+            },
+        }
+        await self._protocol.send(message)
+        self._last_send = now
+
+    def set_mode(self, mode: StrategyMode) -> None:
+        LOGGER.info("Switching mode to %s", mode.value)
+        self.config.mode = mode
+        self._strategy = make_strategy(mode, self.config)
+        self._planner.update_strategy(self._strategy)
+
+    def register_plugin(self, plugin: "BasePlugin") -> None:
+        self._plugins[plugin.name] = plugin
+        plugin.on_register(self)
+
+    async def emit_event(self, event: str, **payload) -> None:
+        for plugin in self._plugins.values():
+            await plugin.handle(event, **payload)
+
+
+class BasePlugin:
+    name = "base"
+
+    def on_register(self, bot: SlitherBot) -> None:  # pragma: no cover - interface
+        self.bot = bot
+
+    async def handle(self, event: str, **payload) -> None:  # pragma: no cover - interface
+        pass

--- a/slitherbot/cli.py
+++ b/slitherbot/cli.py
@@ -1,0 +1,50 @@
+"""Command line entry point for running the Slither bot."""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+from typing import Iterable
+
+from .bot import SlitherBot
+from .config import BotConfig, StrategyMode
+
+
+def parse_arguments(argv: Iterable[str] | None = None) -> BotConfig:
+    parser = argparse.ArgumentParser(description="Run the Slither automation bot")
+    parser.add_argument("server", help="Websocket URL of the Slither server")
+    parser.add_argument("nickname", help="Nickname to use for the bot")
+    parser.add_argument(
+        "--mode",
+        default=StrategyMode.FARM.value,
+        choices=[mode.value for mode in StrategyMode],
+        help="Initial strategy mode",
+    )
+    parser.add_argument(
+        "--config",
+        nargs="*",
+        default=(),
+        help="Extra key=value overrides (e.g. reconnect_attempts=10)",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        help="Logging level",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+    config = BotConfig(server_url=args.server, nickname=args.nickname, mode=StrategyMode(args.mode))
+    if args.config:
+        overrides = BotConfig.from_iterable(args.config)
+        config = BotConfig(**{**config.__dict__, **overrides.__dict__})  # type: ignore[arg-type]
+    return config
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    config = parse_arguments(argv)
+    bot = SlitherBot(config)
+    asyncio.run(bot.run())
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/slitherbot/config.py
+++ b/slitherbot/config.py
@@ -1,0 +1,89 @@
+"""Configuration utilities for the Slither bot."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Iterable, List, Tuple
+
+
+class StrategyMode(str, Enum):
+    """Supported modes the bot can run in."""
+
+    FARM = "farm"
+    HUNT = "hunt"
+    SURVIVAL = "survival"
+
+
+@dataclass(slots=True)
+class MovementTuning:
+    """Fine tuning parameters for motion heuristics."""
+
+    base_speed: float = 2.5
+    boost_speed: float = 4.5
+    turning_rate: float = 180.0  # degrees per second
+    dodge_distance: float = 45.0  # units to consider for evasion
+    food_scan_radius: float = 180.0
+    aggression_threshold: float = 220.0
+    retreat_threshold: float = 75.0
+
+
+@dataclass(slots=True)
+class SensorTuning:
+    """Parameters controlling awareness of the map."""
+
+    history_length: int = 8
+    snake_tracking_radius: float = 260.0
+    enemy_prediction_horizon: float = 1.4
+    food_decay_seconds: float = 6.0
+    hazard_scan_angle: float = 120.0
+
+
+@dataclass(slots=True)
+class BotConfig:
+    """High level configuration for the Slither bot."""
+
+    server_url: str = "ws://localhost:4444"
+    nickname: str = "BOT"
+    mode: StrategyMode = StrategyMode.FARM
+    reconnect_attempts: int = 5
+    reconnect_backoff: float = 2.0
+    heartbeat_interval: float = 3.5
+    send_rate_limit: float = 0.03
+    movement_tuning: MovementTuning = field(default_factory=MovementTuning)
+    sensor_tuning: SensorTuning = field(default_factory=SensorTuning)
+    forbidden_names: Tuple[str, ...] = ("admin", "moderator")
+    preferred_targets: Tuple[str, ...] = tuple()
+    plugins: List[str] = field(default_factory=list)
+
+    def sanitized_nickname(self) -> str:
+        """Return a nickname adjusted to avoid forbidden names."""
+
+        lowered = self.nickname.lower()
+        if any(bad in lowered for bad in self.forbidden_names):
+            return "BOT" if "bot" not in lowered else f"{self.nickname}_1"
+        return self.nickname
+
+    @classmethod
+    def from_iterable(cls, args: Iterable[str]) -> "BotConfig":
+        """Create a configuration from CLI style key=value arguments."""
+
+        kwargs = {}
+        for item in args:
+            if "=" not in item:
+                raise ValueError(f"Invalid configuration override: {item}")
+            key, value = item.split("=", 1)
+            key = key.strip()
+            value = value.strip()
+            if key == "mode":
+                kwargs[key] = StrategyMode(value)
+            elif key in {"reconnect_attempts"}:
+                kwargs[key] = int(value)
+            elif key in {
+                "reconnect_backoff",
+                "heartbeat_interval",
+                "send_rate_limit",
+            }:
+                kwargs[key] = float(value)
+            else:
+                kwargs[key] = value
+        return cls(**kwargs)

--- a/slitherbot/planner.py
+++ b/slitherbot/planner.py
@@ -1,0 +1,58 @@
+"""Decision planner combining strategies with heuristics."""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+from .config import BotConfig
+from .state import GameState, Snake, Vector2, blend_headings
+from .strategies import BaseStrategy, StrategyDecision
+
+
+@dataclass(slots=True)
+class PlannedAction:
+    heading: float
+    boost: bool
+    throttle: float
+    target: Optional[Vector2]
+    reason: str
+
+
+class ActionPlanner:
+    """Refines strategic decisions into low level commands."""
+
+    def __init__(self, config: BotConfig, strategy: BaseStrategy) -> None:
+        self.config = config
+        self.strategy = strategy
+        self._last_heading: float = 0.0
+        self._last_plan: Optional[PlannedAction] = None
+        self._last_time = time.monotonic()
+
+    def step(self, state: GameState, now: float) -> PlannedAction:
+        decision = self.strategy.select(state, now)
+        snake = state.self_snake()
+        if not snake:
+            return PlannedAction(heading=self._last_heading, boost=False, throttle=0.0, target=None, reason="waiting")
+
+        dt = max(now - self._last_time, 1e-3)
+        heading = blend_headings(
+            self._last_heading or snake.heading,
+            decision.heading,
+            self.config.movement_tuning.turning_rate,
+            dt,
+        )
+        throttle = self.config.movement_tuning.boost_speed if decision.boost else self.config.movement_tuning.base_speed
+
+        plan = PlannedAction(heading=heading, boost=decision.boost, throttle=throttle, target=decision.target, reason=decision.reason)
+        self._last_heading = heading
+        self._last_plan = plan
+        self._last_time = now
+        return plan
+
+    @property
+    def last_plan(self) -> Optional[PlannedAction]:
+        return self._last_plan
+
+    def update_strategy(self, strategy: BaseStrategy) -> None:
+        self.strategy = strategy

--- a/slitherbot/protocol.py
+++ b/slitherbot/protocol.py
@@ -1,0 +1,91 @@
+"""Minimal WebSocket protocol helpers for communicating with a Slither server."""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any, AsyncIterator, Dict, Optional
+
+import websockets
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class IncomingMessage:
+    type: str
+    payload: Dict[str, Any]
+
+
+class SlitherProtocol:
+    """Handles the websocket communication with a slither-like server."""
+
+    def __init__(self, uri: str, heartbeat_interval: float) -> None:
+        self._uri = uri
+        self._heartbeat_interval = heartbeat_interval
+        self._ws: Optional[websockets.WebSocketClientProtocol] = None
+        self._receiver_task: Optional[asyncio.Task[None]] = None
+        self._queue: asyncio.Queue[IncomingMessage] = asyncio.Queue()
+        self._stop = asyncio.Event()
+
+    async def __aenter__(self) -> "SlitherProtocol":
+        LOGGER.info("Connecting to %s", self._uri)
+        self._ws = await websockets.connect(self._uri, max_size=2 ** 23)
+        self._stop.clear()
+        self._receiver_task = asyncio.create_task(self._receiver())
+        asyncio.create_task(self._heartbeat())
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.close()
+
+    async def close(self) -> None:
+        if self._receiver_task:
+            self._stop.set()
+            await self._receiver_task
+        if self._ws:
+            await self._ws.close()
+            self._ws = None
+
+    async def _receiver(self) -> None:
+        assert self._ws is not None
+        try:
+            async for raw_message in self._ws:
+                try:
+                    data = json.loads(raw_message)
+                except json.JSONDecodeError:
+                    LOGGER.warning("Unparseable message: %s", raw_message)
+                    continue
+                message_type = data.get("type", "unknown")
+                payload = data.get("payload", {})
+                await self._queue.put(IncomingMessage(type=message_type, payload=payload))
+        except websockets.ConnectionClosed as exc:
+            LOGGER.warning("Connection closed: %s", exc)
+        finally:
+            await self._queue.put(IncomingMessage(type="disconnect", payload={}))
+
+    async def _heartbeat(self) -> None:
+        assert self._ws is not None
+        while not self._stop.is_set():
+            try:
+                await asyncio.sleep(self._heartbeat_interval)
+                await self.send({"type": "heartbeat", "payload": {"time": time.time()}})
+            except asyncio.CancelledError:  # pragma: no cover - cooperative cancellation
+                break
+            except Exception as exc:  # pragma: no cover - network errors
+                LOGGER.error("Heartbeat failure: %s", exc)
+                break
+
+    async def send(self, message: Dict[str, Any]) -> None:
+        if not self._ws:
+            raise RuntimeError("WebSocket is not connected")
+        await self._ws.send(json.dumps(message))
+
+    async def messages(self) -> AsyncIterator[IncomingMessage]:
+        while True:
+            message = await self._queue.get()
+            yield message
+            if message.type == "disconnect":
+                break

--- a/slitherbot/state.py
+++ b/slitherbot/state.py
@@ -1,0 +1,127 @@
+"""Game state tracking for the Slither bot."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from math import atan2, cos, hypot, sin
+from typing import Dict, Iterable, List, Optional, Tuple
+
+import numpy as np
+
+
+@dataclass(slots=True)
+class Vector2:
+    x: float
+    y: float
+
+    def __iter__(self):
+        return iter((self.x, self.y))
+
+    def distance_to(self, other: "Vector2") -> float:
+        return hypot(self.x - other.x, self.y - other.y)
+
+    def angle_to(self, other: "Vector2") -> float:
+        return np.degrees(atan2(other.y - self.y, other.x - self.x)) % 360.0
+
+    def moved_towards(self, heading_deg: float, distance: float) -> "Vector2":
+        rad = np.radians(heading_deg)
+        return Vector2(self.x + cos(rad) * distance, self.y + sin(rad) * distance)
+
+    def lerp(self, other: "Vector2", alpha: float) -> "Vector2":
+        return Vector2(self.x + (other.x - self.x) * alpha, self.y + (other.y - self.y) * alpha)
+
+
+@dataclass(slots=True)
+class Food:
+    position: Vector2
+    mass: float
+    created: float
+
+
+@dataclass(slots=True)
+class Snake:
+    id: str
+    position: Vector2
+    heading: float
+    length: float
+    speed: float
+    is_self: bool = False
+    name: Optional[str] = None
+
+    def predicted_position(self, delta_seconds: float) -> Vector2:
+        return self.position.moved_towards(self.heading, self.speed * delta_seconds)
+
+
+@dataclass(slots=True)
+class Hazard:
+    """Regions that the bot should avoid."""
+
+    center: Vector2
+    radius: float
+    expires: float
+
+
+@dataclass(slots=True)
+class GameState:
+    """Mutable representation of the known game world."""
+
+    tick: int = 0
+    snakes: Dict[str, Snake] = field(default_factory=dict)
+    foods: List[Food] = field(default_factory=list)
+    hazards: List[Hazard] = field(default_factory=list)
+    world_size: Tuple[int, int] = (1200, 1200)
+
+    def self_snake(self) -> Optional[Snake]:
+        return next((snake for snake in self.snakes.values() if snake.is_self), None)
+
+    def update_food(self, foods: Iterable[Food]) -> None:
+        self.foods.extend(foods)
+        self.foods.sort(key=lambda f: f.mass, reverse=True)
+
+    def decay_food(self, now: float, decay_seconds: float) -> None:
+        self.foods = [food for food in self.foods if now - food.created <= decay_seconds]
+
+    def update_snakes(self, snakes: Iterable[Snake]) -> None:
+        for snake in snakes:
+            self.snakes[snake.id] = snake
+
+    def remove_snake(self, snake_id: str) -> None:
+        self.snakes.pop(snake_id, None)
+
+    def prune_hazards(self, now: float) -> None:
+        self.hazards = [hazard for hazard in self.hazards if hazard.expires > now]
+
+    def mark_hazard(self, center: Vector2, radius: float, expires: float) -> None:
+        self.hazards.append(Hazard(center=center, radius=radius, expires=expires))
+
+    def nearest_food(self, origin: Vector2) -> Optional[Food]:
+        return min(self.foods, key=lambda food: origin.distance_to(food.position), default=None)
+
+    def threats_in_radius(self, origin: Vector2, radius: float) -> List[Snake]:
+        return [snake for snake in self.snakes.values() if not snake.is_self and origin.distance_to(snake.position) <= radius]
+
+    def best_target(self, origin: Vector2, preferred_names: Tuple[str, ...]) -> Optional[Snake]:
+        candidates = [snake for snake in self.snakes.values() if not snake.is_self]
+        if not candidates:
+            return None
+        weights: List[Tuple[float, Snake]] = []
+        for snake in candidates:
+            distance = origin.distance_to(snake.position)
+            preference_bonus = 0.0
+            if snake.name:
+                lowered = snake.name.lower()
+                if any(pref.lower() in lowered for pref in preferred_names):
+                    preference_bonus = 1.5
+            weight = (snake.length / max(distance, 1.0)) + preference_bonus
+            weights.append((weight, snake))
+        weights.sort(key=lambda item: item[0], reverse=True)
+        return weights[0][1]
+
+
+def blend_headings(current: float, target: float, rate: float, dt: float) -> float:
+    """Return a heading that smoothly approaches the target."""
+
+    diff = (target - current + 540.0) % 360.0 - 180.0
+    max_step = rate * dt
+    if abs(diff) <= max_step:
+        return target
+    return (current + max_step * np.sign(diff)) % 360.0

--- a/slitherbot/strategies.py
+++ b/slitherbot/strategies.py
@@ -1,0 +1,83 @@
+"""Strategy implementations for different bot behaviours."""
+from __future__ import annotations
+
+import random
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+from .config import BotConfig, StrategyMode
+from .state import GameState, Snake, Vector2, blend_headings
+
+
+@dataclass(slots=True)
+class StrategyDecision:
+    heading: float
+    boost: bool
+    target: Optional[Vector2] = None
+    reason: str = "idle"
+
+
+class BaseStrategy:
+    """Common logic shared by every strategy."""
+
+    def __init__(self, config: BotConfig) -> None:
+        self.config = config
+        self.last_reason = "startup"
+
+    def _default_decision(self, snake: Snake) -> StrategyDecision:
+        return StrategyDecision(heading=snake.heading, boost=False, target=None, reason="hold")
+
+    def select(self, state: GameState, now: float) -> StrategyDecision:
+        snake = state.self_snake()
+        if not snake:
+            return StrategyDecision(heading=0.0, boost=False, target=None, reason="no-self")
+        return self._select(state, snake, now)
+
+    def _select(self, state: GameState, snake: Snake, now: float) -> StrategyDecision:  # pragma: no cover - abstract
+        raise NotImplementedError
+
+
+class FarmStrategy(BaseStrategy):
+    def _select(self, state: GameState, snake: Snake, now: float) -> StrategyDecision:
+        food = state.nearest_food(snake.position)
+        if food:
+            heading = snake.position.angle_to(food.position)
+            return StrategyDecision(heading=heading, boost=False, target=food.position, reason="food")
+        world_w, world_h = state.world_size
+        center = Vector2(world_w / 2, world_h / 2)
+        heading = blend_headings(snake.heading, snake.position.angle_to(center), self.config.movement_tuning.turning_rate, 0.05)
+        return StrategyDecision(heading=heading, boost=False, target=center, reason="center")
+
+
+class HuntStrategy(BaseStrategy):
+    def _select(self, state: GameState, snake: Snake, now: float) -> StrategyDecision:
+        target = state.best_target(snake.position, self.config.preferred_targets)
+        if target is None:
+            return FarmStrategy(self.config)._select(state, snake, now)
+        heading = snake.position.angle_to(target.position)
+        distance = snake.position.distance_to(target.position)
+        boost = distance < self.config.movement_tuning.aggression_threshold
+        return StrategyDecision(heading=heading, boost=boost, target=target.position, reason="hunt")
+
+
+class SurvivalStrategy(BaseStrategy):
+    def _select(self, state: GameState, snake: Snake, now: float) -> StrategyDecision:
+        threats = state.threats_in_radius(snake.position, self.config.movement_tuning.dodge_distance)
+        if threats:
+            mean_angle = sum(snake.position.angle_to(threat.position) for threat in threats) / len(threats)
+            heading = (mean_angle + 180.0) % 360.0
+            return StrategyDecision(heading=heading, boost=True, target=None, reason="evade")
+        farm_decision = FarmStrategy(self.config)._select(state, snake, now)
+        farm_decision.reason = "patrol"
+        return farm_decision
+
+
+def make_strategy(mode: StrategyMode, config: BotConfig) -> BaseStrategy:
+    if mode is StrategyMode.FARM:
+        return FarmStrategy(config)
+    if mode is StrategyMode.HUNT:
+        return HuntStrategy(config)
+    if mode is StrategyMode.SURVIVAL:
+        return SurvivalStrategy(config)
+    raise ValueError(f"Unsupported mode: {mode}")


### PR DESCRIPTION
## Summary
- scaffold a Python package for running a self-hosted slither.io automation bot
- add configurable strategies for farming, hunting, and survival behaviours with an action planner and websocket protocol client
- document setup, configuration, and expected JSON messages between the bot and a compatible server

## Testing
- python -m compileall slitherbot

------
https://chatgpt.com/codex/tasks/task_e_68e4f2419634833093824319dea9d8e4